### PR TITLE
Fix htmldata stylesheet links

### DIFF
--- a/classes/template/htmldata.php
+++ b/classes/template/htmldata.php
@@ -65,8 +65,8 @@ class htmldata {
         }
 
         $html = "
-            <link href=\"https://moodle.aulaemvideo.com.br/theme/boost_magnific/_editor/libs/aos/aos.css\" rel=\"stylesheet\">
-            <link href=\"https://moodle.aulaemvideo.com.br/theme/boost_magnific/_editor/libs/aos/aos.js\" rel=\"stylesheet\">
+            <link href=\"/theme/boost_magnific/_editor/libs/aos/aos.css\" rel=\"stylesheet\">
+            <link href=\"/theme/boost_magnific/_editor/libs/aos/aos.js\" rel=\"stylesheet\">
             " . trim($html);
         return $html;
     }


### PR DESCRIPTION
Nas linhas 68 e 69 o link para os arquivos aos.css e aos.js estão apontando para uma URL que está fora do ar. Removendo o domínio, o site volta a funcionar normalmente.